### PR TITLE
Remove `OpenStruct` from `Context`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "master"
+  pull_request:
+    branches:
+      - "master"
 
 jobs:
   spec:

--- a/interactor.gemspec
+++ b/interactor.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
 
-  spec.add_dependency "ostruct"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end

--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -114,9 +114,7 @@ module Interactor
   def run
     run!
   rescue Failure => e
-    if context.object_id != e.context.object_id
-      raise
-    end
+    raise unless context.equal?(e.context)
   end
 
   # Internal: Invoke an Interactor instance along with all defined hooks. The

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -1,5 +1,3 @@
-require "ostruct"
-
 module Interactor
   # Public: The object for tracking state of an Interactor's invocation. The
   # context is used to initialize the interactor with the information required
@@ -28,7 +26,7 @@ module Interactor
   #   # => "baz"
   #   context
   #   # => #<Interactor::Context foo="baz" hello="world">
-  class Context < OpenStruct
+  class Context
     # Internal: Initialize an Interactor::Context or preserve an existing one.
     # If the argument given is an Interactor::Context, the argument is returned.
     # Otherwise, a new Interactor::Context is initialized from the provided
@@ -57,6 +55,58 @@ module Interactor
         context
       else
         new(context)
+      end
+    end
+
+    def initialize(context = {})
+      @table = {}
+      context&.each { |key, value| self[key] = value }
+    end
+
+    # Public: Read a context attribute by key.
+    def [](key)
+      @table[key.to_sym]
+    end
+
+    # Public: Write a context attribute by key, normalising to symbol.
+    def []=(key, value)
+      @table[key.to_sym] = value
+    end
+
+    # Public: Return all user-set attributes as a Hash (excludes internal state).
+    def to_h
+      @table.dup
+    end
+
+    def ==(other)
+      other.is_a?(Context) && @table == other.send(:table)
+    end
+
+    def eql?(other)
+      other.is_a?(Context) && @table.eql?(other.send(:table))
+    end
+
+    def hash
+      @table.hash
+    end
+
+    def inspect
+      pairs = @table.map { |k, v| "#{k}=#{v.inspect}" }
+      "#<#{self.class}#{" #{pairs.join(", ")}" unless pairs.empty?}>"
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      method_name.to_s.end_with?("=") || @table.key?(method_name.to_sym) || super
+    end
+
+    # Dynamic getter/setter for arbitrary context attributes.
+    # Setters end with "="; getters return nil for unset keys.
+    def method_missing(method_name, *args)
+      name = method_name.to_s
+      if name.end_with?("=")
+        @table[name.delete_suffix("=").to_sym] = args.first
+      else
+        @table[method_name.to_sym]
       end
     end
 
@@ -143,7 +193,7 @@ module Interactor
     #
     # Raises Interactor::Failure initialized with the Interactor::Context.
     def fail!(context = {})
-      context.each { |key, value| self[key.to_sym] = value }
+      context.each { |key, value| self[key] = value }
       @failure = true
       raise Failure, self
     end
@@ -171,7 +221,7 @@ module Interactor
     #
     # Raises Interactor::Halt initialized with the Interactor::Context.
     def halt!(context = {})
-      context.each { |key, value| self[key.to_sym] = value }
+      context.each { |key, value| self[key] = value }
       @halted = true
       raise Halt, self
     end
@@ -204,6 +254,7 @@ module Interactor
     # Returns true if rolled back successfully or false if already rolled back.
     def rollback!
       return false if @rolled_back || halted?
+
       _called.reverse_each(&:rollback)
       @rolled_back = true
     end
@@ -250,12 +301,25 @@ module Interactor
     #   end
     #
     # Returns the context as a hash, including success, failure, and halted
-    def deconstruct_keys(keys)
-      to_h.merge(
+    def deconstruct_keys(_keys)
+      @table.merge(
         success: success?,
         failure: failure?,
         halted: halted?
       )
+    end
+
+    private
+
+    attr_reader :table
+
+    def initialize_copy(orig)
+      super
+      @table = orig.send(:table).dup
+      @called = orig._called.dup
+      @failure = nil
+      @halted = nil
+      @rolled_back = nil
     end
   end
 end

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -1,3 +1,5 @@
+require "set"
+
 module Interactor
   # Public: The object for tracking state of an Interactor's invocation. The
   # context is used to initialize the interactor with the information required
@@ -9,6 +11,11 @@ module Interactor
   # for the purpose of rollback.
   #
   # The context may be manipulated using arbitrary getter and setter methods.
+  #
+  # A context is not safe for concurrent writes: the first write of a key may
+  # define a singleton accessor (see RESERVED_NAMES), which mutates the
+  # instance's singleton class. Share a context across threads for reads only,
+  # or guard writes externally.
   #
   # Examples
   #
@@ -27,6 +34,25 @@ module Interactor
   #   context
   #   # => #<Interactor::Context foo="baz" hello="world">
   class Context
+    # Internal: Method names the context relies on for its own behaviour (its
+    # public/internal API plus the core object protocol it calls). A context key
+    # matching one of these is stored in @table and stays reachable through #[]
+    # and #to_h, but is never installed as a singleton accessor - so user data
+    # can never silently override a method the class itself depends on.
+    #
+    # Names added by *other* libraries (e.g. ActiveSupport's Object#to_json) are
+    # intentionally absent: those are shadowed by a singleton accessor so a
+    # stored value reads back, which is the entire reason accessors exist.
+    RESERVED_NAMES = Set[
+      :[], :[]=, :==, :eql?, :equal?, :hash, :dig, :dup, :clone, :freeze,
+      :frozen?, :to_h, :to_s, :inspect, :class, :is_a?, :kind_of?, :instance_of?,
+      :nil?, :send, :__send__, :singleton_class, :define_singleton_method,
+      :instance_variable_get, :instance_variable_set, :method, :methods,
+      :respond_to?, :respond_to_missing?, :method_missing, :object_id,
+      :marshal_dump, :marshal_load, :deconstruct_keys, :success?, :failure?,
+      :halted?, :fail!, :halt!, :called!, :rollback!, :_called
+    ].freeze
+
     # Internal: Initialize an Interactor::Context or preserve an existing one.
     # If the argument given is an Interactor::Context, the argument is returned.
     # Otherwise, a new Interactor::Context is initialized from the provided
@@ -71,7 +97,7 @@ module Interactor
     # Public: Write a context attribute by key, normalising to symbol.
     def []=(key, value)
       key = key.to_sym
-      define_accessor(key) unless singleton_class.method_defined?(key, false)
+      define_accessor(key) if define_accessor?(key)
       @table[key] = value
     end
 
@@ -81,15 +107,23 @@ module Interactor
     end
 
     def ==(other)
-      other.is_a?(Context) && @table == other.send(:table)
+      other.is_a?(Context) && @table == other.instance_variable_get(:@table)
     end
 
     def eql?(other)
-      other.is_a?(Context) && @table.eql?(other.send(:table))
+      other.is_a?(Context) && @table.eql?(other.instance_variable_get(:@table))
     end
 
     def hash
       @table.hash
+    end
+
+    # Public: Freeze the context. Freezes the backing table too so that, as with
+    # OpenStruct, subsequent writes raise FrozenError rather than silently
+    # succeeding.
+    def freeze
+      @table.freeze
+      super
     end
 
     def inspect
@@ -318,15 +352,24 @@ module Interactor
 
     private
 
-    attr_reader :table
+    # Whether a singleton accessor should be installed for the given key.
+    #
+    # A plain key (one that does not shadow an existing method) is served by
+    # #method_missing, so no accessor is needed - keeping ordinary contexts free
+    # of per-key singleton methods. An accessor is installed only when the key
+    # would otherwise be intercepted by an inherited method (e.g. ActiveSupport's
+    # Object#to_json), so the stored value reads back. Reserved names and keys
+    # already backed by an accessor are skipped.
+    def define_accessor?(key)
+      return false if RESERVED_NAMES.include?(key)
+      return false if singleton_class.method_defined?(key, false)
 
-    # Mirror OpenStruct: on the first write of a key, define a getter (and
-    # setter) on this instance's singleton class so the getter outranks any
-    # method inherited from Object - notably ActiveSupport's Object#to_json,
-    # which application code relies on reading back as a stored context value.
-    # The `false` argument to method_defined? (in #[]=) stops the lookup walking
-    # up to Object; without it, names like :to_json would always look "defined"
-    # and the singleton override would never be installed.
+      respond_to?(key, true)
+    end
+
+    # Define a getter (and setter) on this instance's singleton class so they
+    # outrank the inherited method the key shadows. See #define_accessor? for
+    # when this is invoked.
     def define_accessor(key)
       define_singleton_method(key) { @table[key] }
       define_singleton_method("#{key}=") { |value| @table[key] = value }
@@ -334,8 +377,8 @@ module Interactor
 
     def initialize_copy(orig)
       super
-      @table = orig.send(:table).dup
-      @table.each_key { |key| define_accessor(key) }
+      @table = orig.to_h
+      @table.each_key { |key| define_accessor(key) if define_accessor?(key) }
       @called = orig._called.dup
       @failure = nil
       @halted = nil

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -101,8 +101,12 @@ module Interactor
       @table[key] = value
     end
 
-    # Public: Return all user-set attributes as a Hash (excludes internal state).
-    def to_h
+    # Public: Return all user-set attributes as a Hash (excludes internal
+    # state). Mirrors OpenStruct#to_h: with a block, each key/value pair is
+    # transformed; without one, a shallow copy is returned.
+    def to_h(&block)
+      return @table.to_h(&block) if block
+
       @table.dup
     end
 
@@ -167,6 +171,12 @@ module Interactor
       if name.end_with?("=")
         self[name.delete_suffix("=").to_sym] = args.first
       else
+        # Mirror OpenStruct: a getter takes no arguments, so flag caller bugs
+        # rather than silently ignoring them.
+        unless args.empty?
+          raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 0)"
+        end
+
         @table[method_name.to_sym]
       end
     end

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -97,6 +97,11 @@ module Interactor
       "#<#{self.class}#{" #{pairs.join(", ")}" unless pairs.empty?}>"
     end
 
+    # OpenStruct aliased to_s to inspect; preserve that so Interactor::Failure
+    # messages (Exception#message calls context.to_s) stay readable rather than
+    # falling back to Object#to_s (#<Interactor::Context:0x...>).
+    alias_method :to_s, :inspect
+
     def respond_to_missing?(method_name, include_private = false)
       method_name.to_s.end_with?("=") || @table.key?(method_name.to_sym) || super
     end

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -70,7 +70,9 @@ module Interactor
 
     # Public: Write a context attribute by key, normalising to symbol.
     def []=(key, value)
-      @table[key.to_sym] = value
+      key = key.to_sym
+      define_accessor(key) unless singleton_class.method_defined?(key, false)
+      @table[key] = value
     end
 
     # Public: Return all user-set attributes as a Hash (excludes internal state).
@@ -104,7 +106,7 @@ module Interactor
     def method_missing(method_name, *args)
       name = method_name.to_s
       if name.end_with?("=")
-        @table[name.delete_suffix("=").to_sym] = args.first
+        self[name.delete_suffix("=").to_sym] = args.first
       else
         @table[method_name.to_sym]
       end
@@ -313,9 +315,22 @@ module Interactor
 
     attr_reader :table
 
+    # Mirror OpenStruct: on the first write of a key, define a getter (and
+    # setter) on this instance's singleton class so the getter outranks any
+    # method inherited from Object - notably ActiveSupport's Object#to_json,
+    # which application code relies on reading back as a stored context value.
+    # The `false` argument to method_defined? (in #[]=) stops the lookup walking
+    # up to Object; without it, names like :to_json would always look "defined"
+    # and the singleton override would never be installed.
+    def define_accessor(key)
+      define_singleton_method(key) { @table[key] }
+      define_singleton_method("#{key}=") { |value| @table[key] = value }
+    end
+
     def initialize_copy(orig)
       super
       @table = orig.send(:table).dup
+      @table.each_key { |key| define_accessor(key) }
       @called = orig._called.dup
       @failure = nil
       @halted = nil

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -106,6 +106,12 @@ module Interactor
       @table.dup
     end
 
+    # Public: Extract a nested value, mirroring OpenStruct#dig (and Hash#dig).
+    # The first key is normalised to a symbol to match attribute storage.
+    def dig(key, *rest)
+      @table.dig(key.to_sym, *rest)
+    end
+
     def ==(other)
       other.is_a?(Context) && @table == other.instance_variable_get(:@table)
     end
@@ -124,6 +130,20 @@ module Interactor
     def freeze
       @table.freeze
       super
+    end
+
+    # Public: Serialize only the attribute table. Because set keys define
+    # singleton methods, the default Marshal path raises "singleton can't be
+    # dumped"; dumping just @table keeps contexts marshallable (e.g. cached or
+    # enqueued) and rebuilds accessors on load. Transient state (called list,
+    # failure/halted flags) is intentionally not preserved.
+    def marshal_dump
+      @table
+    end
+
+    def marshal_load(table)
+      @table = table
+      rebuild_accessors
     end
 
     def inspect
@@ -375,10 +395,17 @@ module Interactor
       define_singleton_method("#{key}=") { |value| @table[key] = value }
     end
 
+    # Install singleton accessors for every stored key that needs one. Used
+    # after @table is replaced wholesale (dup/clone, Marshal load) rather than
+    # built up key-by-key through #[]=.
+    def rebuild_accessors
+      @table.each_key { |key| define_accessor(key) if define_accessor?(key) }
+    end
+
     def initialize_copy(orig)
       super
       @table = orig.to_h
-      @table.each_key { |key| define_accessor(key) if define_accessor?(key) }
+      rebuild_accessors
       @called = orig._called.dup
       @failure = nil
       @halted = nil

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -144,11 +144,9 @@ module Interactor
       end
 
       it "makes the context available from the failure" do
-        begin
-          context.fail!
-        rescue Failure => error
-          expect(error.context).to eq(context)
-        end
+        context.fail!
+      rescue Failure => error
+        expect(error.context).to eq(context)
       end
     end
 
@@ -435,7 +433,11 @@ module Interactor
 
       it "resets failure state so a dup of a failed context starts fresh" do
         original = Context.build(foo: "bar")
-        original.fail! rescue nil
+        begin
+          original.fail!
+        rescue
+          nil
+        end
         copy = original.dup
         expect(copy.failure?).to eq(false)
         expect(copy.success?).to eq(true)
@@ -443,7 +445,11 @@ module Interactor
 
       it "resets halted state so a dup of a halted context starts fresh" do
         original = Context.build(foo: "bar")
-        original.halt! rescue nil
+        begin
+          original.halt!
+        rescue
+          nil
+        end
         copy = original.dup
         expect(copy.halted?).to eq(false)
       end
@@ -485,7 +491,7 @@ module Interactor
         end
 
         it "supports rightward assignment for halted:" do
-          context => { halted: }
+          context => {halted:}
           expect(halted).to be(true)
         end
       end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -288,6 +288,173 @@ module Interactor
       end
     end
 
+    describe "dynamic attributes" do
+      let(:context) { Context.build }
+
+      it "sets and reads attributes via method syntax" do
+        context.foo = "bar"
+        expect(context.foo).to eq("bar")
+      end
+
+      it "returns nil for unset attributes" do
+        expect(context.missing_key).to be_nil
+      end
+
+      it "overwrites previously set attributes" do
+        context.foo = "bar"
+        context.foo = "baz"
+        expect(context.foo).to eq("baz")
+      end
+
+      it "responds to setter methods" do
+        expect(context.respond_to?(:foo=)).to eq(true)
+      end
+
+      it "responds to getter methods only after the key is set" do
+        expect(context.respond_to?(:foo)).to eq(false)
+        context.foo = "bar"
+        expect(context.respond_to?(:foo)).to eq(true)
+      end
+
+      it "normalises string keys to symbols" do
+        context["foo"] = "bar"
+        expect(context.foo).to eq("bar")
+        expect(context[:foo]).to eq("bar")
+      end
+    end
+
+    describe "#[] and #[]=" do
+      let(:context) { Context.build }
+
+      it "reads and writes with symbol keys" do
+        context[:foo] = "bar"
+        expect(context[:foo]).to eq("bar")
+      end
+
+      it "normalises string keys on write" do
+        context["foo"] = "bar"
+        expect(context[:foo]).to eq("bar")
+      end
+
+      it "normalises string keys on read" do
+        context[:foo] = "bar"
+        expect(context["foo"]).to eq("bar")
+      end
+    end
+
+    describe "#to_h" do
+      it "returns user-set attributes as a hash" do
+        context = Context.build(foo: "bar", baz: 42)
+        expect(context.to_h).to eq(foo: "bar", baz: 42)
+      end
+
+      it "does not include internal state flags" do
+        context = Context.build(foo: "bar")
+        begin
+          context.fail!
+        rescue
+          nil
+        end
+        hash = context.to_h
+        expect(hash.keys).not_to include(:failure, :success, :halted)
+      end
+
+      it "returns a copy that does not affect the context" do
+        context = Context.build(foo: "bar")
+        hash = context.to_h
+        hash[:foo] = "mutated"
+        expect(context.foo).to eq("bar")
+      end
+    end
+
+    describe "#==" do
+      it "is equal to another context with the same attributes" do
+        context1 = Context.build(foo: "bar")
+        context2 = Context.build(foo: "bar")
+        expect(context1).to eq(context2)
+      end
+
+      it "is not equal to a context with different attributes" do
+        context1 = Context.build(foo: "bar")
+        context2 = Context.build(foo: "baz")
+        expect(context1).not_to eq(context2)
+      end
+
+      it "is not equal to a plain hash" do
+        context = Context.build(foo: "bar")
+        expect(context).not_to eq(foo: "bar")
+      end
+    end
+
+    describe "#eql? and #hash" do
+      it "two contexts with the same attributes are eql?" do
+        context1 = Context.build(foo: "bar")
+        context2 = Context.build(foo: "bar")
+        expect(context1.eql?(context2)).to eq(true)
+      end
+
+      it "two contexts with different attributes are not eql?" do
+        context1 = Context.build(foo: "bar")
+        context2 = Context.build(foo: "baz")
+        expect(context1.eql?(context2)).to eq(false)
+      end
+
+      it "equal contexts have the same hash value" do
+        context1 = Context.build(foo: "bar")
+        context2 = Context.build(foo: "bar")
+        expect(context1.hash).to eq(context2.hash)
+      end
+
+      it "can be used as a Hash key with value semantics" do
+        context1 = Context.build(foo: "bar")
+        context2 = Context.build(foo: "bar")
+        h = {context1 => :found}
+        expect(h[context2]).to eq(:found)
+      end
+    end
+
+    describe "#dup (initialize_copy)" do
+      let(:instance1) { double(:instance1) }
+      let(:instance2) { double(:instance2) }
+
+      it "dups the @table so attribute mutations are isolated" do
+        original = Context.build(foo: "bar")
+        copy = original.dup
+        copy.foo = "baz"
+        expect(original.foo).to eq("bar")
+      end
+
+      it "dups @called so rollback lists are independent" do
+        original = Context.build
+        original.called!(instance1)
+        copy = original.dup
+        copy.called!(instance2)
+        expect(original._called).to eq([instance1])
+        expect(copy._called).to eq([instance1, instance2])
+      end
+
+      it "resets failure state so a dup of a failed context starts fresh" do
+        original = Context.build(foo: "bar")
+        original.fail! rescue nil
+        copy = original.dup
+        expect(copy.failure?).to eq(false)
+        expect(copy.success?).to eq(true)
+      end
+
+      it "resets halted state so a dup of a halted context starts fresh" do
+        original = Context.build(foo: "bar")
+        original.halt! rescue nil
+        copy = original.dup
+        expect(copy.halted?).to eq(false)
+      end
+    end
+
+    describe "OpenStruct removal" do
+      it "does not inherit from OpenStruct" do
+        expect(Context.superclass).to eq(Object)
+      end
+    end
+
     describe "#deconstruct_keys" do
       let(:context) { Context.build(foo: :bar) }
 

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -12,7 +12,7 @@ module Interactor
         context = Context.build
 
         expect(context).to be_a(Context)
-        expect(context.send(:table)).to eq({})
+        expect(context.to_h).to eq({})
       end
 
       it "doesn't affect the original hash" do
@@ -382,6 +382,12 @@ module Interactor
         context = Context.build(foo: "bar")
         expect(context).not_to eq(foo: "bar")
       end
+
+      it "is equal regardless of attribute insertion order" do
+        context1 = Context.build(foo: "bar", baz: "qux")
+        context2 = Context.build(baz: "qux", foo: "bar")
+        expect(context1).to eq(context2)
+      end
     end
 
     describe "#eql? and #hash" do
@@ -477,6 +483,64 @@ module Interactor
         context = Context.build
         context.display = "stored-payload"
         expect(context.dup.display).to eq("stored-payload")
+      end
+
+      it "does not install a singleton accessor for a plain key" do
+        context = Context.build
+        context.foo = "bar"
+        expect(context.singleton_methods).not_to include(:foo)
+        expect(context.foo).to eq("bar")
+      end
+
+      it "installs a singleton accessor only for keys shadowing a method" do
+        context = Context.build
+        context.display = "stored-payload"
+        expect(context.singleton_methods).to include(:display)
+      end
+    end
+
+    describe "reserved names" do
+      it "stores a reserved key without overriding the method" do
+        context = Context.build
+        context[:hash] = "stored"
+        # #hash still returns the real Integer identity hash, not "stored",
+        # while the value remains reachable through #[].
+        expect(context.hash).to eq({hash: "stored"}.hash)
+        expect(context[:hash]).to eq("stored")
+      end
+
+      it "keeps #to_h working when a :to_h key is stored" do
+        context = Context.build(to_h: "stored", foo: "bar")
+        expect(context.to_h).to eq(to_h: "stored", foo: "bar")
+        expect(context[:to_h]).to eq("stored")
+      end
+
+      it "keeps equality working when a reserved key is stored" do
+        context1 = Context.build(hash: "x")
+        context2 = Context.build(hash: "x")
+        expect(context1).to eq(context2)
+      end
+
+      # Guards against silent divergence: if a new public method is added to
+      # Context without reserving its name, a user key of the same name would
+      # shadow it. This fails loudly instead.
+      it "reserves every method the class defines" do
+        own_methods = Context.instance_methods(false)
+        unreserved = own_methods.reject { |name| Context::RESERVED_NAMES.include?(name) }
+        expect(unreserved).to eq([])
+      end
+    end
+
+    describe "#freeze" do
+      it "raises when writing to a frozen context" do
+        context = Context.build(foo: "bar")
+        context.freeze
+        expect { context.baz = "qux" }.to raise_error(FrozenError)
+      end
+
+      it "reports itself as frozen" do
+        context = Context.build.freeze
+        expect(context).to be_frozen
       end
     end
 

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -480,6 +480,21 @@ module Interactor
       end
     end
 
+    describe "#to_s" do
+      it "matches #inspect so attribute info is not lost" do
+        context = Context.build(foo: "bar")
+        expect(context.to_s).to eq(context.inspect)
+        expect(context.to_s).to include('foo="bar"')
+      end
+
+      it "keeps Interactor::Failure messages readable" do
+        context = Context.build(foo: "bar")
+        context.fail!
+      rescue Failure => error
+        expect(error.message).to include('foo="bar"')
+      end
+    end
+
     describe "#deconstruct_keys" do
       let(:context) { Context.build(foo: :bar) }
 

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -544,6 +544,50 @@ module Interactor
       end
     end
 
+    describe "#dig" do
+      it "reads a top-level attribute" do
+        context = Context.build(foo: "bar")
+        expect(context.dig(:foo)).to eq("bar")
+      end
+
+      it "digs into nested values" do
+        context = Context.build(foo: {a: {b: 1}})
+        expect(context.dig(:foo, :a, :b)).to eq(1)
+      end
+
+      it "normalises a string first key" do
+        context = Context.build(foo: {a: 1})
+        expect(context.dig("foo", :a)).to eq(1)
+      end
+
+      it "returns nil for a missing key" do
+        expect(Context.build.dig(:missing, :nope)).to be_nil
+      end
+    end
+
+    describe "Marshal round-trip" do
+      it "dumps and loads an attribute-bearing context" do
+        context = Context.build(foo: "bar", count: 3)
+        restored = Marshal.load(Marshal.dump(context))
+        expect(restored).to eq(context)
+        expect(restored.foo).to eq("bar")
+      end
+
+      it "rebuilds accessors for shadowing keys after load" do
+        context = Context.build
+        context.display = "stored-payload"
+        restored = Marshal.load(Marshal.dump(context))
+        expect(restored.display).to eq("stored-payload")
+      end
+
+      it "starts a restored context in a fresh, successful state" do
+        context = Context.build(foo: "bar")
+        restored = Marshal.load(Marshal.dump(context))
+        expect(restored.success?).to eq(true)
+        expect(restored._called).to eq([])
+      end
+    end
+
     describe "#to_s" do
       it "matches #inspect so attribute info is not lost" do
         context = Context.build(foo: "bar")

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -459,6 +459,25 @@ module Interactor
       it "does not inherit from OpenStruct" do
         expect(Context.superclass).to eq(Object)
       end
+
+      # Regression guard for the real-world failure mode: in the application,
+      # ActiveSupport adds Object#to_json and ~32 endpoints store a rendered
+      # payload as context.to_json then read it back. A plain method_missing
+      # implementation lets that read fall through to the inherited method.
+      # ActiveSupport is not loaded in this gem's own suite, so we reproduce the
+      # same shadowing with Kernel#display, which exists on every Object here;
+      # the application-level to_json case is covered by the Docsketch suite.
+      it "returns the stored value for a key shadowing an inherited method" do
+        context = Context.build
+        context.display = "stored-payload"
+        expect(context.display).to eq("stored-payload")
+      end
+
+      it "preserves the shadowing override across dup" do
+        context = Context.build
+        context.display = "stored-payload"
+        expect(context.dup.display).to eq("stored-payload")
+      end
     end
 
     describe "#deconstruct_keys" do

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -298,6 +298,11 @@ module Interactor
         expect(context.missing_key).to be_nil
       end
 
+      it "raises ArgumentError when a getter is called with arguments" do
+        context.foo = "bar"
+        expect { context.foo(1) }.to raise_error(ArgumentError)
+      end
+
       it "overwrites previously set attributes" do
         context.foo = "bar"
         context.foo = "baz"
@@ -362,6 +367,12 @@ module Interactor
         hash = context.to_h
         hash[:foo] = "mutated"
         expect(context.foo).to eq("bar")
+      end
+
+      it "transforms pairs when given a block" do
+        context = Context.build(foo: "bar")
+        result = context.to_h { |key, value| [key.to_s, value.upcase] }
+        expect(result).to eq("foo" => "BAR")
       end
     end
 


### PR DESCRIPTION
The `Context` class has been updated to replace the use of `OpenStruct` with a custom implementation. This change improves performance and enhances type safety within the codebase.