### PR TITLE
Declare required_ruby_version >= 3.1

### DIFF
--- a/interactor.gemspec
+++ b/interactor.gemspec
@@ -11,6 +11,8 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/Bidsketch/interactor"
   spec.license = "MIT"
 
+  spec.required_ruby_version = ">= 3.1"
+
   spec.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
 
   spec.add_dependency "ostruct"


### PR DESCRIPTION
## Problem

The gemspec declares no `required_ruby_version`. Bundler/RubyGems will therefore install `interactor` on any Ruby, including versions the gem isn't tested against — where it then fails at runtime on syntax/APIs it relies on (e.g. `String#delete_suffix`, Ruby 2.5+). The failure surfaces as an obscure runtime crash rather than a clear resolution-time error.

## Change

```ruby
spec.required_ruby_version = ">= 3.1"
```

`>= 3.1` matches the actually-supported range:
- CI matrix runs `3.1`, `3.2`, `3.3`, `3.4`, and `head`.
- `.standard.yml` pins `ruby_version: 3.1.4`.

With the constraint, an unsupported Ruby is rejected at `bundle install` / `gem install` with a clear message instead of crashing later.

## Notes

- Independent of #3 (the OpenStruct removal); branched off `master` so it can merge on its own.
- No code or test changes — gemspec metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)